### PR TITLE
new location of kubernetes repo

### DIFF
--- a/replacements/FNAL/kubernetes.repo
+++ b/replacements/FNAL/kubernetes.repo
@@ -1,7 +1,7 @@
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.24/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni


### PR DESCRIPTION
the google kubernetes rpm repo was taken down March 1 2024.
This change points to the new one that allows the bootstrap_k8s.sh
to successfully install kubeadm, kubectl, etc